### PR TITLE
Fix shellcheck require path

### DIFF
--- a/lua/plugins/autoformatting.lua
+++ b/lua/plugins/autoformatting.lua
@@ -48,7 +48,7 @@ return {
 			formatting.terraform_fmt,
 			require("none-ls.formatting.ruff").with({ extra_args = { "--extend-select", "I" } }),
 			require("none-ls.formatting.ruff_format"),
-			diagnostics.shellcheck,
+                        require("none-ls.diagnostics.shellcheck"),
 			diagnostics.actionlint,
 			diagnostics.yamllint,
 			diagnostics.markdownlint,


### PR DESCRIPTION
## Summary
- update autoformatting config to use `require("none-ls.diagnostics.shellcheck")`

## Testing
- `luajit - <<'EOF'
local f,err=loadfile('lua/plugins/autoformatting.lua')
assert(f, err)
f()
print('ok')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684ee18fbe04832e9ee451960da04530
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix require path for `shellcheck` in `autoformatting.lua`.
> 
>   - **Behavior**:
>     - Update `autoformatting.lua` to use `require("none-ls.diagnostics.shellcheck")` instead of `diagnostics.shellcheck`.
>   - **Testing**:
>     - Verified with `luajit` script to ensure no errors in loading `autoformatting.lua`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Studykeepyell%2Fnvim&utm_source=github&utm_medium=referral)<sup> for d74c59d36a82487450fae0357d68024f9d76582b. You can [customize](https://app.ellipsis.dev/Studykeepyell/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->