### PR TITLE
Fix bufferline highlight

### DIFF
--- a/lua/plugins/bufferline.lua
+++ b/lua/plugins/bufferline.lua
@@ -5,15 +5,15 @@ return {
 		"nvim-tree/nvim-web-devicons",
 	},
 	config = function()
-		require("bufferline").setup({
-			options = {
-				mode = "buffers", -- set to "tabs" to only show tabpages instead
-				themable = true, -- allows highlight groups to be overriden i.e. sets highlights as default
-				numbers = "none", -- | "ordinal" | "buffer_id" | "both" | function({ ordinal, id, lower, raise }): string,
-				close_command = "Bdelete! %d", -- can be a string | function, see "Mouse actions"
-				buffer_close_icon = "✗",
-				close_icon = "✗",
-				path_components = 1, -- Show only the file name without the directory
+                require("bufferline").setup({
+                        options = {
+                                mode = "buffers", -- set to "tabs" to only show tabpages instead
+                                themable = true, -- allows highlight groups to be overriden i.e. sets highlights as default
+                                numbers = "none", -- | "ordinal" | "buffer_id" | "both" | function({ ordinal, id, lower, raise }): string,
+                                close_command = "Bdelete! %d", -- can be a string | function, see "Mouse actions"
+                                buffer_close_icon = "✗",
+                                close_icon = "✗",
+                                path_components = 1, -- Show only the file name without the directory
 				modified_icon = "●",
 				left_trunc_marker = "",
 				right_trunc_marker = "",
@@ -37,16 +37,19 @@ return {
 				},
 				icon_pinned = "󰐃",
 				minimum_padding = 1,
-				maximum_padding = 5,
-				maximum_length = 15,
-				sort_by = "insert_at_end",
-			},
-			highlights = {
-				separator = { fg = "#5fff87", bg = "NONE" },
-				separator_visible = { fg = "#5fff87", bg = "NONE" },
-				separator_selected = { fg = "#8affff", bg = "NONE" },
-			},
-		})
+                                maximum_padding = 5,
+                                maximum_length = 15,
+                                sort_by = "insert_at_end",
+                                filter = function(buf)
+                                        return vim.bo[buf.id].filetype ~= "qf"
+                                end,
+                        },
+                        highlights = {
+                                separator = { fg = "#5fff87", bg = "#202328" },
+                                separator_visible = { fg = "#5fff87", bg = "#202328" },
+                                separator_selected = { fg = "#8affff", bg = "#202328" },
+                        },
+                })
 
 		-- 1) Make quickfix buffers unmodifiable & hide from buffer list:
 		vim.api.nvim_create_autocmd("FileType", {
@@ -65,13 +68,5 @@ return {
 			end,
 		})
 
-		-- 2) Update your bufferline setup to filter out qf buffers:
-		require("bufferline").setup({
-			options = {
-				filter = function(buf)
-					return vim.bo[buf.id].filetype ~= "qf"
-				end,
-			},
-		})
-	end,
+        end,
 }


### PR DESCRIPTION
## Summary
- configure `bufferline.nvim` once
- give bufferline separators opaque backgrounds

## Testing
- `nvim --version | head -n 3`


------
https://chatgpt.com/codex/tasks/task_e_68671b821068832e8d53b5718004766a
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidates `bufferline.nvim` setup, adds quickfix buffer filter, and changes separator backgrounds to opaque.
> 
>   - **Configuration**:
>     - Consolidates `bufferline.nvim` setup into a single call in `lua/plugins/bufferline.lua`.
>     - Adds a filter to exclude quickfix buffers from the bufferline.
>   - **Visuals**:
>     - Changes separator backgrounds to opaque in `lua/plugins/bufferline.lua`.
>   - **Behavior**:
>     - Quickfix buffers are made unmodifiable and hidden from the buffer list.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=Studykeepyell%2Fnvim&utm_source=github&utm_medium=referral)<sup> for b2637d290e20d00aa9d4250451795eb406ba64ce. You can [customize](https://app.ellipsis.dev/Studykeepyell/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->